### PR TITLE
Misc changes

### DIFF
--- a/vanilla_first_setup/gtk/progress.ui
+++ b/vanilla_first_setup/gtk/progress.ui
@@ -31,7 +31,7 @@
         </child>
         <child>
             <object class="GtkProgressBar" id="progressbar">
-              <property name="margin-top">40</property>
+              <property name="margin-top">12</property>
               <property name="margin-start">40</property>
               <property name="margin-bottom">40</property>
               <property name="margin-end">40</property>

--- a/vanilla_first_setup/gtk/progress.ui
+++ b/vanilla_first_setup/gtk/progress.ui
@@ -16,8 +16,21 @@
             </object>
         </child>
         <child>
+            <object class="GtkLabel" id="progressbar_text">
+                <property name="wrap">True</property>
+                <property name="wrap-mode">word-char</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="margin-top">40</property>
+                <property name="margin-start">40</property>
+                <property name="label" translatable="true">The changes are being applied. Please Wait…</property>
+                <style>
+                    <class name="title-4"/>
+                </style>
+            </object>
+        </child>
+        <child>
             <object class="GtkProgressBar" id="progressbar">
-              <property name="text" translatable="true">The changes are being applied. Please Wait…</property>
               <property name="show-text">true</property>
               <property name="margin-top">40</property>
               <property name="margin-start">40</property>

--- a/vanilla_first_setup/gtk/progress.ui
+++ b/vanilla_first_setup/gtk/progress.ui
@@ -31,7 +31,6 @@
         </child>
         <child>
             <object class="GtkProgressBar" id="progressbar">
-              <property name="show-text">true</property>
               <property name="margin-top">40</property>
               <property name="margin-start">40</property>
               <property name="margin-bottom">40</property>

--- a/vanilla_first_setup/gtk/window.ui
+++ b/vanilla_first_setup/gtk/window.ui
@@ -10,12 +10,12 @@
       <object class="GtkBox">
         <property name="orientation">vertical</property>
         <child>
-          <object class="AdwHeaderBar">
+          <object class="AdwHeaderBar" id="headerbar">
             <style>
               <class name="flat" />
             </style>
             <property name="title_widget">
-              <object class="AdwCarouselIndicatorDots">
+              <object class="AdwCarouselIndicatorDots" id="carousel_indicator_dots">
                 <property name="carousel">carousel</property>
                 <property name="orientation">horizontal</property>
               </object>

--- a/vanilla_first_setup/window.py
+++ b/vanilla_first_setup/window.py
@@ -31,6 +31,8 @@ class VanillaWindow(Adw.ApplicationWindow):
     __gtype_name__ = 'VanillaWindow'
 
     carousel = Gtk.Template.Child()
+    carousel_indicator_dots = Gtk.Template.Child()
+    headerbar = Gtk.Template.Child()
     btn_back = Gtk.Template.Child()
     toasts = Gtk.Template.Child()
 
@@ -85,9 +87,13 @@ class VanillaWindow(Adw.ApplicationWindow):
 
         if page not in [self.__view_progress, self.__view_done]:
             self.btn_back.set_visible(cur_index != 0.0)
+            self.carousel_indicator_dots.set_visible(cur_index != 0.0)
+            self.headerbar.set_show_end_title_buttons(cur_index != 0.0)
             return
 
         self.btn_back.set_visible(False)
+        self.carousel_indicator_dots.set_visible(False)
+        self.headerbar.set_show_end_title_buttons(False)
 
         # keep the btn_back button locked if this is the last page
         if page == self.__view_done:


### PR DESCRIPTION
make `progress_screen` and `done` pages have no carousel and title-buttons becuase:
- carousel in `progress_screen/tour` will confuse users that the carousel_indicators are for tour and not for pages
-  hide `titlebuttons` as it's not to close the window when changes are being applied
- also made progress-bar text as label (_same as vanilla installer_)

### screenshots:
 ![image](https://user-images.githubusercontent.com/54065734/200173703-f4e64dc7-4975-4612-b06d-65b6c526a2a2.png) 
![imagee](https://user-images.githubusercontent.com/54065734/200173810-a2cbbec0-fe91-4328-b078-7cb4dc6e56b9.png)

 