### PR TITLE
fixed hyperlink directing to ABRoot documentation

### DIFF
--- a/recipe.json
+++ b/recipe.json
@@ -15,7 +15,7 @@
              "icon": "security-medium-symbolic",
              "title": "Immutable and Atomic",
              "description": "Vanilla OS is an immutable and atomic Linux distribution. It is based on Ubuntu and uses ABRoot to provide atomic transactions.",
-             "read_more_link": "https://documentation.vanillaos.org/docs/abroot/"
+             "read_more_link": "https://documentation.vanillaos.org/docs/ABRoot/"
         },
         "apx": {
              "icon": "vanilla-container-terminal-symbolic",


### PR DESCRIPTION
During setup i realized a dead end when following the "Read More" button in first-setup.

I know these are small changes i tried this as my first contribution including a pull request to an open source project ever.
So i'd be over the moon seeing it merged into upstream. ;-D

Cheers 