### PR TITLE
fix: Change conn-check syntax

### DIFF
--- a/vanilla_first_setup/utils/processor.py
+++ b/vanilla_first_setup/utils/processor.py
@@ -85,12 +85,13 @@ class Processor:
             if "VANILLA_FAKE" in os.environ:
                 f.write("echo 'VANILLA_FAKE is set, not running commands'\n")
                 f.write("exit 0\n")
-            
+
             # connection test
-            f.write("wget -q --spider cloudflare.com")
-            f.write("if [ $? != 0 ]; then")
-            f.write("echo 'No internet connection!'")
-            f.write("exit 1")
+            f.write("wget -q --spider cloudflare.com\n")
+            f.write("if [ $? != 0 ]; then\n")
+            f.write("echo 'No internet connection!'\n")
+            f.write("exit 1\n")
+            f.write("fi\n")
 
             for command in commands:
                 if command.startswith("!nextBoot"):


### PR DESCRIPTION
Using the stock `recipe.json`, I encountered some syntax errors around the conn-check in the `NamedTemporaryFile` in `utils/processor.py`;

```bash
wget -q --spider cloudflare.comif [ $? != 0 ]; thenecho 'No internet connection!'exit 1export DEBIAN_FRONTEND=noninteractive
```

where it should look like:

```bash
wget -q --spider cloudflare.com
if [ $? != 0 ]; then
echo 'No internet connection!'
exit 1
fi

export DEBIAN_FRONTEND=noninteractive
[...]
```
