### PR TITLE
Fix css-provider getting too many arguments

### DIFF
--- a/vanilla_first_setup/main.py
+++ b/vanilla_first_setup/main.py
@@ -71,7 +71,7 @@ class FirstSetupApplication(Adw.Application):
 
         CSS inspired by: Sonny Piers <https://github.com/sonnyp>
         """
-        css = """
+        css = b"""
 .theme-selector {
     border-radius: 100px;
     margin: 8px;
@@ -113,7 +113,7 @@ class FirstSetupApplication(Adw.Application):
 }
 """
         provider = Gtk.CssProvider()
-        provider.load_from_data(css, -1)
+        provider.load_from_data(data=css)
         Gtk.StyleContext.add_provider_for_display(
             display=Gdk.Display.get_default(),
             provider=provider,


### PR DESCRIPTION
Fixes first-setup failing to start due to `CssProvider().load_from_data()` getting too many arguments