### PR TITLE
Fix the first setup custom session

### DIFF
--- a/data/firstsetup.desktop
+++ b/data/firstsetup.desktop
@@ -6,4 +6,5 @@ TryExec=gnome-shell
 Icon=
 Type=Application
 DesktopNames=vanilla:GNOME
+X-GDM-SessionRegisters=true
 X-Ubuntu-Gettext-Domain=gnome-session-3.0

--- a/data/meson.build
+++ b/data/meson.build
@@ -4,6 +4,11 @@ install_data(
 )
 
 install_data(
+     'firstsetup.desktop',
+     install_dir: join_paths(get_option('datadir'), 'wayland-sessions')
+)
+
+install_data(
     'org.vanillaos.FirstSetup.NewUser.desktop',
     install_dir: join_paths(get_option('datadir'), 'applications')
 )


### PR DESCRIPTION
Adds the X-GDM-SessionRegisters property to the session desktop file and installs it to both xsessions and wayland-sessions.

Closes #206 