### PR TITLE
Change accountsservice file on finish

### DIFF
--- a/first_setup_post_boot
+++ b/first_setup_post_boot
@@ -19,3 +19,7 @@ fi
 if [ -e '/etc/org.vanillaos.FirstSetup.nextBoot' ]; then
     rm /etc/org.vanillaos.FirstSetup.nextBoot
 fi
+
+if [ -e "/var/lib/AccountsService/users/$USER" ]; then
+    sed 's/Session=firstsetup/Session=gnome/g' -i "/var/lib/AccountsService/users/$USER"
+fi


### PR DESCRIPTION
Changes the session in the accountsservice file for the user running first-setup to gnome, ensuring that the user does not log into the first setup session again

Requires change in vanilla-installer/albius, ~~PR to be done~~ change added in https://github.com/Vanilla-OS/vanilla-installer/commit/7bc03be840d5d4c626ff2490641cd6fead2a105b
Unlocks https://github.com/Vanilla-OS/desktop-image/pull/12
Closes #197 upon merging this and related pull requests