### PR TITLE
Hide Custom Session in GDM

### DIFF
--- a/data/firstsetup.desktop
+++ b/data/firstsetup.desktop
@@ -8,3 +8,4 @@ Type=Application
 DesktopNames=vanilla:GNOME
 X-GDM-SessionRegisters=true
 X-Ubuntu-Gettext-Domain=gnome-session-3.0
+NoDisplay=true


### PR DESCRIPTION
Adds the NoDisplay property to the custom first setup session, so that it is hidden from the user but can still be set as the default and used by AccountsService