### PR TITLE
fix: [close #223] Make wifi refresh thread-safe

### DIFF
--- a/vanilla_first_setup/defaults/network.py
+++ b/vanilla_first_setup/defaults/network.py
@@ -267,6 +267,7 @@ class VanillaDefaultNetwork(Adw.Bin):
         # there's a high change that it coincides with a periodic
         # refresh operation.
         self.__wifi_lock = Lock()
+        self.__scan_lock = Lock()
 
         # Since we have a dedicated page for checking connectivity,
         # we only need to make sure the user has some type of
@@ -351,7 +352,7 @@ class VanillaDefaultNetwork(Adw.Bin):
             device_type = device.get_device_type()
             if device_type == NM.DeviceType.ETHERNET:
                 self.__add_ethernet_connection(device)
-            if device_type == NM.DeviceType.WIFI:
+            elif device_type == NM.DeviceType.WIFI:
                 self.__scan_wifi(device)
 
         self.set_btn_next(self.has_eth_connection or self.has_wifi_connection)
@@ -412,10 +413,15 @@ class VanillaDefaultNetwork(Adw.Bin):
         self.wired_group.add(eth_conn)
         self.__wired_children.append(eth_conn)
 
-    def __refresh_wifi_list(self, conn: NM.DeviceWifi):
+    def __poll_wifi_scan(self, conn: NM.DeviceWifi):
+        self.__scan_lock.acquire()
         while conn.get_last_scan() == self.__last_wifi_scan:
             time.sleep(0.25)
+        self.__scan_lock.release()
 
+        GLib.idle_add(self.__refresh_wifi_list, conn)
+
+    def __refresh_wifi_list(self, conn: NM.DeviceWifi):
         networks = {}
         for ap in conn.get_access_points():
             ssid = ap.get_ssid()
@@ -472,10 +478,12 @@ class VanillaDefaultNetwork(Adw.Bin):
         self.__wifi_lock.release()
 
     def __scan_wifi(self, conn: NM.DeviceWifi):
+        self.__scan_lock.acquire()
         self.__last_wifi_scan = conn.get_last_scan()
+        self.__scan_lock.release()
         conn.request_scan_async()
 
-        t = Timer(1.5, self.__refresh_wifi_list, [conn])
+        t = Timer(1.5, self.__poll_wifi_scan, [conn])
         t.start()
 
     @property
@@ -492,3 +500,4 @@ class VanillaDefaultNetwork(Adw.Bin):
             [it[0] for it in list(self.__wireless_children.values())],
             (("connected", True), ("signal_strength", True), ("ssid", True)),
         )
+


### PR DESCRIPTION
This commit fixes a crash that happens when refreshing wifi networks on the network page by calling the UI refresh code inside the main thread.