### PR TITLE
fix:[#228] first setup looping and not selecting gnome as the login environment

### DIFF
--- a/__first_setup_reset_session
+++ b/__first_setup_reset_session
@@ -2,7 +2,7 @@
 
 LOGIN_USERS=$(getent passwd | awk -F ':' "\$3 >= $(grep UID_MIN /etc/login.defs | cut -d " " -f 2) { print \$1 }" | uniq | sed '/^nobody$/d')
 if [ "$(echo "${LOGIN_USERS}" | wc -l)" -gt 1 ]; then
-    echo '[User]\nLanguage=\nXSession=gnome\nSystemAccount=true' > /var/lib/AccountsService/users/vanilla
+    echo -e '[User]\nLanguage=\nXSession=gnome\nSystemAccount=true' > /var/lib/AccountsService/users/vanilla
 fi
 
 echo '[daemon]' > /etc/gdm3/daemon.conf

--- a/recipe.json
+++ b/recipe.json
@@ -4,9 +4,9 @@
     "distro_logo": "org.vanillaos.FirstSetup-flower",
     "pre_run": [],
     "post_run": [
-        "sh /usr/bin/__first_setup_reset_session",
+        "sh -c /usr/bin/__first_setup_reset_session",
         "abroot pkg apply",
-        "!nextBoot sh /usr/bin/__first_setup_cleanup"
+        "!nextBoot sh -c /usr/bin/__first_setup_cleanup"
     ],
     "tour": {
         "get-involved": {


### PR DESCRIPTION
The login session is set in `/var/lib/AccountsService/users/$REAL_USER`. This fails because the bash script is interpreted by dash, not bash. That also means that the AccountsService file for the vanilla user is set but not the one for $REAL_USER.

![grafik](https://github.com/Vanilla-OS/first-setup/assets/44101694/e21d2e3c-0d64-4070-be2e-6c39e1acfccc)
![grafik](https://github.com/Vanilla-OS/first-setup/assets/44101694/5d7c04ad-f025-4992-a7c2-a672bb4049e4)

Setting the -c flag runs the bash script as a command instead and works as expected.

Secondly, the flag -e for echo is missing in the first part of the script. This means that \n is not interpreted as a newline but instead just written to the file. (The file for the $REAL_USER is written correctly using the -e flag)

![grafik](https://github.com/Vanilla-OS/first-setup/assets/44101694/1e1256fb-e737-4844-ba79-3335922c483e)

After a reboot, gdm (I think) detects that the file `/var/lib/AccountsService/users/vanilla` is formatted incorrectly and would delete both configurations, also the correct one. (for some reason)

This causes gdm to show no user accounts and also defaults back to the default session (first setup), which causes the loop.

This PR fixes both issues.
Tested three times in a VM to rule out any inconsistencies. (worked correctly 3/3 times) 