### PR TITLE
fix [#276 #284]: removes handling of password

### DIFF
--- a/vanilla_first_setup/gtk/default-user.ui
+++ b/vanilla_first_setup/gtk/default-user.ui
@@ -52,18 +52,6 @@
                             <property name="input-purpose">name</property>
                           </object>
                         </child>
-                        <child>
-                          <object class="AdwPasswordEntryRow" id="password_entry">
-                            <property name="title" translatable="yes">Password</property>
-                            <property name="input-purpose">password</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwPasswordEntryRow" id="password_confirmation">
-                            <property name="title" translatable="yes">Confirm Password</property>
-                            <property name="input-purpose">password</property>
-                          </object>
-                        </child>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
The way that passwords are handled currently is insecure, see:
Fixes #276 
Fixes #284 

The password should never be written on disk in plaintext.

Implementing it in a safe and robust manner would probably require a completely different architecture. 
For this reason, it is probably better to hand this responsibility to the display manager. If a password is expired, the display manager will ask for a new password, removing the need for setting it through first setup. 