### PR TITLE
fix [#269]: runs user commands with dbus access

### DIFF
--- a/vanilla_first_setup/utils/processor.py
+++ b/vanilla_first_setup/utils/processor.py
@@ -54,7 +54,7 @@ class Processor:
                 command = command.replace("!noRoot", "")
                 command = command.replace('"', '\\"')
                 command = command.replace("'", "\\'")
-                command = 'su - $REAL_USER -c "%s"' % command
+                command = "systemd-run --user --machine=\"$REAL_USER@.host\" -P -q /usr/bin/bash -c \"%s\"" % command
 
             next_boot.append(command)
 
@@ -115,7 +115,7 @@ class Processor:
                     command = command.replace("!noRoot", "")
                     command = command.replace('"', '\\"')
                     command = command.replace("'", "\\'")
-                    command = "su - $USER -c '%s'" % command
+                    command = "systemd-run --user --machine=\"$USER@.host\" -P -q /usr/bin/bash -c \"%s\"" % command
 
                 # outRun bang is used to run a command outside of the main
                 # shell script.


### PR DESCRIPTION
Setting the theme doesn't work if gsettings can't access the dbus. 
This uses systemd-run instead of su, to create a user environment with dbus. 

Fixes #269 