### PR TITLE
fix [#287]: removes unnecessary desktop file

### DIFF
--- a/data/org.vanillaos.FirstSetup.desktop.in
+++ b/data/org.vanillaos.FirstSetup.desktop.in
@@ -6,3 +6,4 @@ Terminal=false
 Type=Application
 Categories=GTK;
 StartupNotify=true
+NoDisplay=true

--- a/vanilla_first_setup/utils/processor.py
+++ b/vanilla_first_setup/utils/processor.py
@@ -90,14 +90,6 @@ class Processor:
                 for command in next_boot:
                     f.write(f"echo '{command}' >> " + next_boot_script_path + "\n")
 
-                f.write(f"echo 'echo \"[Desktop Entry]\" > {user_fs_desktop_path}' >> {next_boot_script_path}\n")
-                f.write(f"echo 'echo \"Name=FirstSetup\" >> {user_fs_desktop_path}' >> {next_boot_script_path}\n")
-                f.write(f"echo 'echo \"Comment=FirstSetup\" >> {user_fs_desktop_path}' >> {next_boot_script_path}\n")
-                f.write(f"echo 'echo \"Exec=vanilla-first-setup\" >> {user_fs_desktop_path}' >> {next_boot_script_path}\n")
-                f.write(f"echo 'echo \"Terminal=false\" >> {user_fs_desktop_path}' >> {next_boot_script_path}\n")
-                f.write(f"echo 'echo \"Type=Application\" >> {user_fs_desktop_path}' >> {next_boot_script_path}\n")
-                f.write(f"echo 'echo \"NoDisplay=true\" >> {user_fs_desktop_path}' >> {next_boot_script_path}\n")
-
                 f.write(f"echo '[Desktop Entry]' > {next_boot_autostart_path}\n")
                 f.write(f"echo 'Name=FirstSetup Next Boot' >> {next_boot_autostart_path}\n")
                 f.write(f"echo 'Comment=Run FirstSetup commands at the next boot' >> {next_boot_autostart_path}\n")


### PR DESCRIPTION
Since the first setup is always started automatically, the desktop file should always be hidden in the menu.

Fixes #287 