### PR TITLE
fixes new-user mode

### DIFF
--- a/__first_setup_reset_session
+++ b/__first_setup_reset_session
@@ -1,43 +1,14 @@
 #!/bin/bash
 
-LOGIN_USERS=$(getent passwd | awk -F ':' "\$3 >= $(grep UID_MIN /etc/login.defs | cut -d " " -f 2) { print \$1 }" | uniq | sed '/^nobody$/d')
-if [ "$(echo "${LOGIN_USERS}" | wc -l)" -gt 1 ]; then
-    echo -e '[User]\nLanguage=\nXSession=gnome\nSystemAccount=true' > /var/lib/AccountsService/users/vanilla
-fi
-
+echo -e '[User]\nLanguage=\nXSession=gnome\nSystemAccount=true' > /var/lib/AccountsService/users/vanilla
 echo '[daemon]' > /etc/gdm3/daemon.conf
 
-export highest_uid=$(grep -E "^UID_MIN" /etc/login.defs | awk '{$1=$1};1' | cut -d$' ' -f2)
-export REAL_USER=""
+REAL_USER=""
 
-# Check if the file /etc/vos-user-1000-busy exists
-if [ -f /etc/vos-user-1000-busy ]; then
-    # File exists, find the user with the highest UID
-    while read entry; do
-        uid=$(echo "$entry" | awk 'BEGIN {FS=":"}; {print $3}')
-        name=$(echo "$entry" | awk 'BEGIN {FS=":"}; {print $1}')
-        if [[ $((uid)) -gt $((highest_uid)) && $name != "nobody" ]]; then
-            export highest_uid=$uid
-            export REAL_USER=$name
-        fi
-    done < <(getent passwd)
+if [ -f "/tmp/new-user-name" ]; then
+    REAL_USER=$(cat "/tmp/new-user-name")
 else
-    # File does not exist, check if UID 1000 exists
-    if id -u 1000 >/dev/null 2>&1; then
-        # UID 1000 exists, create the /etc/vos-user-1000-busy file and set REAL_USER to the user with UID 1000
-        touch /etc/vos-user-1000-busy
-        REAL_USER=$(getent passwd 1000 | cut -d: -f1)
-    else
-        # UID 1000 does not exist, find the user with the highest UID
-        while read entry; do
-            uid=$(echo "$entry" | awk 'BEGIN {FS=":"}; {print $3}')
-            name=$(echo "$entry" | awk 'BEGIN {FS=":"}; {print $1}')
-            if [[ $((uid)) -gt $((highest_uid)) && $name != "nobody" ]]; then
-                export highest_uid=$uid
-                export REAL_USER=$name
-            fi
-        done < <(getent passwd)
-    fi
+    REAL_USER=$(getent passwd $PKEXEC_UID | sed 's/:.*//')
 fi
 
 echo -e '[User]\nSession=gnome' > /var/lib/AccountsService/users/$REAL_USER

--- a/vanilla_first_setup/defaults/user.py
+++ b/vanilla_first_setup/defaults/user.py
@@ -77,6 +77,7 @@ class VanillaDefaultUser(Adw.Bin):
                         f'adduser --quiet --disabled-password --shell /bin/bash --gecos "{self.fullname}" {self.username}',
                         f'passwd --delete --expire "{self.username}"',
                         f"usermod -a -G sudo,adm,lpadmin {self.username}",
+                        f"echo {self.username} > /tmp/new-user-name"
                     ],
                 }
             ],

--- a/vanilla_first_setup/main.py
+++ b/vanilla_first_setup/main.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import getpass
 import gi
 
 gi.require_version("Gtk", "4.0")
@@ -103,20 +102,15 @@ class FirstSetupApplication(Adw.Application):
             logger.info("Running post script")
             self.post_script = options.lookup_value("run-post-script").get_string()
 
-        if options.contains("new-user"):
-            self.user = None
+        # FIXME: this is a workaround to avoid running as a new user when the user is not vanilla
+        # this should simply never happen. Anyway we are already working on a new backend for the
+        # first setup, so this is just a temporary fix
+        if self.user == "vanilla":
             self.new_user = True
-
-            # FIXME: this is a workaround to avoid running as a new user when the user is not vanilla
-            # this should simply never happen. Anyway we are already working on a new backend for the
-            # first setup, so this is just a temporary fix
-            if getpass.getuser() != "vanilla":
-                self.new_user = False
-                logger.warning(
-                    "Asked to run as a new user, but the current user is not vanilla, meaning a new user was already created, turning off the new user mode"
-                )
-            else:
-                logger.info("Running as a new user")
+            logger.warning("Detected user vanilla, creating new user")
+        else:
+            self.new_user = False
+            logger.info("Detected new user, not creating new one")
 
         self.activate()
 

--- a/vanilla_first_setup/utils/processor.py
+++ b/vanilla_first_setup/utils/processor.py
@@ -129,6 +129,9 @@ class Processor:
 
                 f.write(f"{command}\n")
 
+            # prevent privilege escalation
+            f.write(f"chown root:root {commands_script_path}\n")
+
             # run the outRun commands
             if out_run:
                 f.write("if [ $? -eq 0 ]; then")


### PR DESCRIPTION
The new-user mode is actually never called from anywhere. 
This determines the mode from the currently logged in user.

The vanilla user can't be used anyway with the current approach so this workaround won't cause any more problems.

Since  #222 is planned this is a valid workaround in my opinion.

Tested both with a fresh install and with a new user afterwards.