### PR TITLE
fix:[#339] network check without network interface

### DIFF
--- a/vanilla_first_setup/defaults/conn_check.py
+++ b/vanilla_first_setup/defaults/conn_check.py
@@ -23,6 +23,7 @@ from gi.repository import Adw, Gtk
 from requests import Session
 
 from vanilla_first_setup.utils.run_async import RunAsync
+from vanilla_first_setup.utils.network import check_connection
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("FirstSetup::Conn_Check")
@@ -72,21 +73,7 @@ class VanillaDefaultConnCheck(Adw.Bin):
             if "VANILLA_SKIP_CONN_CHECK" in os.environ:
                 return True
 
-            try:
-                s = Session()
-                headers = OrderedDict(
-                    {
-                        "Accept-Encoding": "gzip, deflate, br",
-                        "Host": "vanillaos.org",
-                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:77.0) Gecko/20100101 Firefox/77.0",
-                    }
-                )
-                s.headers = headers
-                s.get("https://vanillaos.org/", headers=headers, verify=True)
-                return True
-            except Exception as e:
-                logger.error(f"Connection check failed: {str(e)}")
-                return False
+            return check_connection()
 
         def callback(res, *args):
             if self.__ignore_callback:

--- a/vanilla_first_setup/defaults/network.py
+++ b/vanilla_first_setup/defaults/network.py
@@ -26,6 +26,7 @@ from threading import Lock, Timer
 from gi.repository import NM, NMA4, Adw, GLib, Gtk
 
 from vanilla_first_setup.utils.run_async import RunAsync
+from vanilla_first_setup.utils.network import check_connection
 
 logger = logging.getLogger("FirstSetup::Network")
 
@@ -286,7 +287,7 @@ class VanillaDefaultNetwork(Adw.Bin):
 
     def __try_skip_page(self, data):
         # Skip page if already connected to the internet
-        if self.has_eth_connection or self.has_wifi_connection:
+        if check_connection():
             self.__window.next()
 
     @property

--- a/vanilla_first_setup/utils/meson.build
+++ b/vanilla_first_setup/utils/meson.build
@@ -8,6 +8,7 @@ sources = [
   'recipe.py',
   'builder.py',
   'parser.py',
+  'network.py',
 ]
 
 install_data(sources, install_dir: utilsdir)

--- a/vanilla_first_setup/utils/network.py
+++ b/vanilla_first_setup/utils/network.py
@@ -1,0 +1,39 @@
+# network.py
+#
+# Copyright 2023 mirkobrombin
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundationat version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from collections import OrderedDict
+from requests import Session
+
+logger = logging.getLogger("FirstSetup::Connector")
+
+
+def check_connection():
+    try:
+        s = Session()
+        headers = OrderedDict(
+            {
+                "Accept-Encoding": "gzip, deflate, br",
+                "Host": "vanillaos.org",
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:77.0) Gecko/20100101 Firefox/77.0",
+            }
+        )
+        s.headers = headers
+        s.get("https://vanillaos.org/", headers=headers, verify=True)
+        return True
+    except Exception as e:
+        logger.error(f"Connection check failed: {str(e)}")
+        return False


### PR DESCRIPTION
- Split out network check from conn_check into static function
- Check for network by request success instead of network interfaces

Closes #339 