### PR TITLE
fix: add network-manager dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,5 +31,6 @@ Depends: python3,
          gir1.2-vte-3.91,
          libnm0,
          libnma0,
+	 network-manager,
          libnma-gtk4-0
 Description: This utility is meant to be used in Vanilla GNOME as a first-setup wizard.


### PR DESCRIPTION
Network manager is required for getting device and interface information.  It should be added as a dependency.