### PR TITLE
Fix vanilla-first-setup-prepare-files permission

### DIFF
--- a/vanilla_first_setup/meson.build
+++ b/vanilla_first_setup/meson.build
@@ -30,6 +30,7 @@ configure_file(
 configure_file(
   input: 'vanilla-first-setup-prepare-files.in',
   output: 'vanilla-first-setup-prepare-files',
+  install_mode: 'rwxr-xr-x',
   configuration: conf,
   install: true,
   install_dir: get_option('bindir')


### PR DESCRIPTION
Providing `vanilla-first-setup-prepare-files` exec grant to allow https://github.com/Vanilla-OS/first-setup/blob/d055de204f6bc4bf9f778a2625d651fb61e42c7c/vanilla_first_setup/utils/processor.py#L65
to be run correctly when first-setup is run as non-root.