### PR TITLE
feat: view logs after post script run

### DIFF
--- a/vanilla_first_setup/gtk/done.ui
+++ b/vanilla_first_setup/gtk/done.ui
@@ -52,16 +52,6 @@
                             </object>
                         </child>
                         <child>
-                            <object class="GtkButton" id="btn_retry">
-                                <property name="label">Retry</property>
-                                <property name="halign">center</property>
-                                <property name="visible">false</property>
-                                <style>
-                                    <class name="pill"/>
-                                </style>
-                            </object>
-                        </child>
-                        <child>
                             <object class="GtkButton" id="btn_close">
                                 <property name="label">Get Started</property>
                                 <property name="halign">center</property>
@@ -69,6 +59,17 @@
                                 <style>
                                     <class name="pill"/>
                                     <class name="suggested-action"/>
+                                </style>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkButton" id="btn_logs">
+                                <property name="label">View Logs</property>
+                                <property name="halign">center</property>
+                                <property name="visible">true</property>
+                                <property name="margin-top">20</property>
+                                <style>
+                                    <class name="pill"/>
                                 </style>
                             </object>
                         </child>

--- a/vanilla_first_setup/gtk/post-script.ui
+++ b/vanilla_first_setup/gtk/post-script.ui
@@ -4,31 +4,52 @@
     <requires lib="libadwaita" version="1.0" />
     <template class="VanillaPostScript" parent="AdwBin">
         <child>
-            <object class="AdwStatusPage">
-                <property name="valign">fill</property>
-                <property name="halign">fill</property>
-                <property name="icon-name">org.vanillaos.FirstSetup-flower</property>
-                <property name="title" translatable="yes">Finalizing</property>
-                <property name="description" translatable="yes">Your device will be ready soon</property>
+            <object class="GtkOverlay">
+                <property name="valign">center</property>
+                <child type="overlay">
+                    <object class="GtkButton" id="btn_next">
+                        <property name="visible">false</property>
+                        <property name="sensitive">True</property>
+                        <property name="margin-end">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="icon-name">go-next-symbolic</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                        <property name="tooltip-text" translatable="yes">Next</property>
+                        <style>
+                            <class name="circular" />
+                            <class name="suggested-action" />
+                        </style>
+                    </object>
+                </child>
                 <child>
-                    <object class="GtkBox" id="console_box">
-                        <property name="margin-start">40</property>
-                        <property name="margin-end">40</property>
-                        <property name="margin-top">1</property>
-                        <property name="margin-bottom">18</property>
-                        <property name="height-request">250</property>
-                        <property name="orientation">vertical</property>
+                    <object class="AdwStatusPage">
+                        <property name="valign">fill</property>
+                        <property name="halign">fill</property>
+                        <property name="icon-name">org.vanillaos.FirstSetup-flower</property>
+                        <property name="title" translatable="yes">Finalizing</property>
+                        <property name="description" translatable="yes">Your device will be ready soon</property>
                         <child>
-                            <object class="GtkBox" id="console_output">
-                                <property name="margin-top">12</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">12</property>
+                            <object class="GtkBox" id="console_box">
+                                <property name="margin-start">50</property>
+                                <property name="margin-end">50</property>
+                                <property name="margin-top">1</property>
+                                <property name="margin-bottom">18</property>
+                                <property name="height-request">250</property>
                                 <property name="orientation">vertical</property>
+                                <child>
+                                    <object class="GtkBox" id="console_output">
+                                        <property name="margin-top">12</property>
+                                        <property name="margin-start">12</property>
+                                        <property name="margin-end">12</property>
+                                        <property name="orientation">vertical</property>
+                                    </object>
+                                </child>
+                                <style>
+                                    <class name="card"/>
+                                </style>
                             </object>
                         </child>
-                        <style>
-                            <class name="card"/>
-                        </style>
                     </object>
                 </child>
             </object>

--- a/vanilla_first_setup/views/done.py
+++ b/vanilla_first_setup/views/done.py
@@ -28,7 +28,7 @@ class VanillaDone(Adw.Bin):
 
     status_page = Gtk.Template.Child()
     btn_reboot = Gtk.Template.Child()
-    btn_retry = Gtk.Template.Child()
+    btn_logs = Gtk.Template.Child()
     btn_close = Gtk.Template.Child()
     log_box = Gtk.Template.Child()
     log_output = Gtk.Template.Child()
@@ -61,9 +61,13 @@ class VanillaDone(Adw.Bin):
 
         self.btn_reboot.set_visible(False)
         self.btn_close.set_visible(True)
+        
+        # hide when progress is previous step
+        if self.__init_mode != 1:
+            self.btn_logs.set_visible(False)
 
         self.btn_close.connect("clicked", self.__on_close_clicked)
-        self.btn_retry.connect("clicked", self.__on_retry_clicked)
+        self.btn_logs.connect("clicked", self.__on_logs_clicked)
         self.btn_reboot.connect("clicked", self.__on_reboot_clicked)
 
     def set_reboot(self):
@@ -113,5 +117,5 @@ class VanillaDone(Adw.Bin):
 
         self.__window.close()
 
-    def __on_retry_clicked(self, *args):
+    def __on_logs_clicked(self, *args):
         self.__window.back()

--- a/vanilla_first_setup/views/post_script.py
+++ b/vanilla_first_setup/views/post_script.py
@@ -22,6 +22,7 @@ class VanillaPostScript(Adw.Bin):
     __gtype_name__ = "VanillaPostScript"
 
     console_output = Gtk.Template.Child()
+    btn_next = Gtk.Template.Child()
 
     def __init__(self, window, post_script: str, **kwargs):
         super().__init__(**kwargs)
@@ -34,6 +35,8 @@ class VanillaPostScript(Adw.Bin):
         self.__font.set_weight(Pango.Weight.NORMAL)
         self.__font.set_stretch(Pango.Stretch.NORMAL)
         self.__style_manager = self.__window.style_manager
+
+        self.btn_next.connect("clicked", self.__on_next_clicked)
 
         self.__build_ui()
 
@@ -104,4 +107,8 @@ class VanillaPostScript(Adw.Bin):
 
     def on_vte_child_exited(self, terminal, status, *args):
         status = not bool(status)
-        self.__window.next(result=status)
+        self.btn_next.set_visible(True)
+        self.__window.set_installation_result(status, self.__terminal)
+
+    def __on_next_clicked(self, *args):
+        self.__window.next()


### PR DESCRIPTION
I reworked the retry button to go back to view logs.  its really annoying when theres an issue and it auto moves to done without letting the user see whats up.  the logging doesnt even work at the moment so its a bear to try to figure out whats wrong with the post scripts.  i plan to address the logging portion of that in another PR.  Also, the retry button doesnt rerun the script so its more or less the same functionality.

- convert retry button to view logs
- add next button to post script view
- increase margin for terminal box

![image](https://github.com/user-attachments/assets/7da506e0-3ea7-4425-bcb9-6c9c9a22480b)
![image](https://github.com/user-attachments/assets/0d718af5-733c-4fcb-88e2-550845dbe410)
