### PR TITLE
feat:[#358] add custom reboot and close commands

### DIFF
--- a/recipe.example.json
+++ b/recipe.example.json
@@ -615,5 +615,7 @@
             ]
         }
     },
+    "close_command": "gnome-session-quit --no-prompt",
+    "reboot_command": "gnome-session-quit --reboot",
     "reboot_condition": "false"
 }

--- a/recipe.json
+++ b/recipe.json
@@ -584,5 +584,7 @@
             ]
         }
     },
+    "close_command": "gnome-session-quit --no-prompt",
+    "reboot_command": "gnome-session-quit --reboot",
     "reboot_condition": "false"
 }

--- a/vanilla_first_setup/views/done.py
+++ b/vanilla_first_setup/views/done.py
@@ -98,7 +98,7 @@ class VanillaDone(Adw.Bin):
             self.btn_close.set_visible(True)
 
     def __on_reboot_clicked(self, *args):
-        subprocess.run(["gnome-session-quit", "--reboot"])
+        subprocess.run(self.__window.recipe["reboot_command"].split())
 
     def __on_close_clicked(self, *args):
         if self.__init_mode == 1:
@@ -109,7 +109,7 @@ class VanillaDone(Adw.Bin):
                     flags=GLib.SpawnFlags.SEARCH_PATH,
                 )
         else:
-            subprocess.run(["gnome-session-quit", "--no-prompt"])
+            subprocess.run(self.__window.recipe["close_command"].split())
 
         self.__window.close()
 


### PR DESCRIPTION
- add recipe keys for reboot and close commands
- call custom commands with subprocess instead hardcoded commands
- add recipe keys to example

closes #358 