### PR TITLE
fix:[#377] allow digits in hostname

### DIFF
--- a/vanilla_first_setup/views/hostname.py
+++ b/vanilla_first_setup/views/hostname.py
@@ -69,7 +69,7 @@ class VanillaHostname(Adw.Bin):
         if len(hostname) > 64:
             return False
 
-        lower_ascii = re.compile(r"[a-z]+$")
+        lower_ascii = re.compile(r"[a-z0-9]+$")
 
         dot_parts = hostname.split(".")
         for dot_part in dot_parts:


### PR DESCRIPTION
Update the regex to allow for digits in the hostname validation.

closes #377 