### PR TITLE
debian: fix architecture

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Vcs-Git: https://github.com/Vanilla-OS/first-setup.git
 Rules-Requires-Root: no
 
 Package: vanilla-first-setup
-Architecture: any
+Architecture: all
 Depends: python3,
          python3-gi,
          python3-tz,


### PR DESCRIPTION
This package does not contain any binary files, so the `architecture` should be set to `all` to mark it as architecture-independent.

Related to https://github.com/Vanilla-OS/live-iso/issues/87.