### PR TITLE
fix [#404]: replaces Evince with Papers

### DIFF
--- a/vanilla_first_setup/apps.json
+++ b/vanilla_first_setup/apps.json
@@ -38,7 +38,7 @@
         },
         {
             "name": "Document Viewer",
-            "id": "org.gnome.Evince"
+            "id": "org.gnome.Papers"
         },
         {
             "name": "File Roller",


### PR DESCRIPTION
Closes #404 